### PR TITLE
Add page title, add explaination to switch

### DIFF
--- a/root/index.html
+++ b/root/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+	<title>Root Scenario Randomizer</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" /> 
 </head>
 

--- a/root/index.html
+++ b/root/index.html
@@ -19,7 +19,7 @@
 	<ul class="controls">
 		<li>
 			<ul class="suggested-labels">
-				<li>🔥</li>
+				<li><abbr title="Filter by combinations recommended in game manual">🔥</abbr></li>
 				<li>&nbsp;</li>
 			</ul>
 			<label class="switch">
@@ -70,6 +70,12 @@
 	a:link, a:visited {
 	  color: #212F3C;
 	  text-decoration: none;
+	}
+	
+	abbr {
+	  text-decoration: none;
+	  padding-bottom: 2px;
+	  border-bottom: dotted black 1px;
 	}
 	
 	.wrapper {


### PR DESCRIPTION
Cool tool! My brother posted it in the family Slack. Without a `title` tag, the title remains as `slack-redir.net...` in my browser tab (Firefox). Also added a little tooltip for the 🔥 control since I was mystified about it at first. The `abbr` tag may not do anything for mobile users though.