### PR TITLE
Fix issue with checking reach with 2 Vagabonds.

### DIFF
--- a/root/index.html
+++ b/root/index.html
@@ -542,13 +542,13 @@ var check = function(results) {
 		totalReach = totalReach + parseInt(results[i].Reach);
 	}
 
-	// Second vagabond counts 2 fewer than the first
+	// Second vagabond counts 3 fewer than the first
 	var textResults = [];
 	for (var i=0; i < results.length; ++i){
 		textResults = textResults.concat(results[i].Faction);
 	}
 	var vagabonds = _.groupBy(textResults)['Vagabond'];
-	if (vagabonds && vagabonds.length === 2) {totalReach = totalReach - 2;}
+	if (vagabonds && vagabonds.length === 2) {totalReach = totalReach - 3;}
 
 	var targetReaches = [17,18,21,25,28]
 	


### PR DESCRIPTION
In this BGG thread: https://boardgamegeek.com/thread/2354098/faction-randomizer-web-app

It was noted that in some situations the Root randomizer wasn't adhering to Reach as defined by the latest living rules. I believe the issue is likely that the code assumes the second Vagabond counts for two less than the first (base value of five). However, the Reach table indicates the second Vagabond should only have a Reach value of two, which is three less than first. I made what I think is the appropriate change in the check function.

Thanks for taking a look and for building a nice tool.

EDIT: fixed link for posterity 